### PR TITLE
Updated requirements-dev document to support testing stage in pipeline

### DIFF
--- a/Contents.md
+++ b/Contents.md
@@ -1,5 +1,5 @@
 
-Navigating the repository:
+# Navigating the repository:
     • /app.py: this script defines and orchestrates high level stack to be deployed.
       
     • /pge_app_infrastructure: this directory contains all substack IaC definitions.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,7 @@
 pytest==6.2.5
+Flask==3.1.0
+scikit-learn==1.6.0
+boto3==1.35.86
+numpy==2.2.0
+jose
+python-jose[cryptography]


### PR DESCRIPTION
Testing stage in pipeline failed because requirements-dev did not include container specific libraries. Updated text doc.